### PR TITLE
Load PySide only if IDA is 6.8 or lower

### DIFF
--- a/diaphora.py
+++ b/diaphora.py
@@ -51,12 +51,12 @@ from idc import *
 from idaapi import *
 from idautils import *
 
-try:
+if IDA_SDK_VERSION < 690:
   # In versions prior to IDA 6.9 PySide is used...
   from PySide import QtGui
   QtWidgets = QtGui
   is_pyqt5 = False
-except ImportError:
+else:
   # ...while in IDA 6.9, they switched to PyQt5
   from PyQt5 import QtCore, QtGui, QtWidgets
   is_pyqt5 = True

--- a/diaphora_import.py
+++ b/diaphora_import.py
@@ -23,10 +23,12 @@ import diaphora
 reload(diaphora)
 from diaphora import import_definitions
 
-try:
+from idaapi import IDA_SDK_VERSION
+
+if IDA_SDK_VERSION < 690:
   # In versions prior to IDA 6.9 PySide is used...
   from PySide import QtGui
-except ImportError:
+else:
   # ...while in IDA 6.9, they switched to PyQt5
   from PyQt5 import QtGui
 

--- a/diaphora_load.py
+++ b/diaphora_load.py
@@ -23,10 +23,12 @@ import diaphora
 reload(diaphora)
 from diaphora import load_results
 
-try:
+from idaapi import IDA_SDK_VERSION
+
+if IDA_SDK_VERSION < 690:
   # In versions prior to IDA 6.9 PySide is used...
   from PySide import QtGui
-except ImportError:
+else:
   # ...while in IDA 6.9, they switched to PyQt5
   from PyQt5 import QtGui
 


### PR DESCRIPTION
Bug: Do not try to load PySide in IDA 6.9 or higher, instead, just import PyQt5 or it may cause conflicts with existing PySide installations.
